### PR TITLE
Correcting Readme.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cmake --build . --target install
 
 Now you installed the strata into your /Application folder. You can run it from searching 'strata' in spotline search.
 
-The manual and examples are packaged inside the strata.app. Right click on the strata.app in finder and choose **"Show Package Contents"**. 
+The manual and examples are packaged inside the strata.app. Right click on the `strata.app` in finder and choose **"Show Package Contents"**. 
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ cmake .. \
 cmake --build . --target install
 ```
 
-Now you installed the strata into your /Application folder. You can run it from searching 'strata' in spotline search. 
+Now you installed the strata into your /Application folder. You can run it from searching 'strata' in spotline search.
+
+The manual and examples are packaged inside the strata.app. Right click on the strata.app in finder and choose **"Show Package Contents"**. 
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -149,21 +149,21 @@ If you find a cleaner way to specific the library paths, please let me know.
 For Apple Silicon (M-Series Chips), the brew installation location is moved to /opt/homebrew. So some installation instruction is different. 
 
 Make sure you have homebrew installed, then install the dependencies as normal. 
-'''bash
+```bash
 brew install qt gsl qwt cmake
-'''
+```
 
 Then clone the git repo, cd into the repo, make the build folder, and then cd into the build folder. 
 
-'''bash
+```bash
 git clone https://github.com/arkottke/strata.git
 cd strata
 mkdir build
 cd build
-'''
+```
 
 Then run the following to compile. 
-'''bash
+```bash
 cmake .. \                      
   -DQWT_ROOT_DIR=$(brew --prefix qwt) \
   -DQWT_INCLUDE_DIR=$(brew --prefix qwt)/lib/qwt.framework/Headers \
@@ -172,7 +172,7 @@ cmake .. \
   -DCMAKE_INSTALL_PREFIX=dist
 
 cmake --build . --target install
-'''
+```
 
 Now you installed the strata into your /Application folder. You can run it from searching 'strata' in spotline search. 
 


### PR DESCRIPTION
The Readme.md didn't display code block correctly. Fixed the issue. 

Also added description on where the example and manuals are. 